### PR TITLE
Adds support for SNS MessageAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ await ServiceDiscovery.request('namespace.service->handler',  body);
 ### Publish an SNS event
 
 ```javascript
-await ServiceDiscovery.publish('namspace.service-name->topic', event, opts);
+await ServiceDiscovery.publish('namspace.service-name->topic', event, {
+  ...opts,
+  attributes: { // Matches params.MessageAttributes from aws-sdk
+    tenant: {
+      DataType: 'String',
+      StringValue: 'foo',
+    },
+  },
+});
 ```
 
 ### Add message to queue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peak-ai/ais-service-discovery",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.js",
   "repository": "git@github.com:PeakBI/ais-service-discovery.git",
   "author": "<ewan.valentine@peak.ai>",

--- a/src/call-service.js
+++ b/src/call-service.js
@@ -68,7 +68,7 @@ const runService = (service, body, opts = {}) => {
     case 'event':
     case 'pubsub':
     case 'sns': {
-      return publisher.publish(arn, body, omit(['subscribe', opts]));
+      return publisher.publish(arn, body, omit(['subscribe'], opts));
     }
 
     default: {

--- a/src/call-service.test.js
+++ b/src/call-service.test.js
@@ -93,8 +93,16 @@ describe('(call)', () => {
     expect.assertions(2);
 
     const event = { name: 'Test' };
-    const res = await ServiceDiscovery.publish('test-namespace.test-service->test-topic', event);
-    expect(SNS.prototype.publish).toBeCalledWith('test-topic', event);
+
+    const attributes = {
+      tenant: {
+        DataType: 'String',
+        StringValue: 'foo',
+      },
+    };
+
+    const res = await ServiceDiscovery.publish('test-namespace.test-service->test-topic', event, { attributes });
+    expect(SNS.prototype.publish).toBeCalledWith('test-topic', event, attributes);
     expect(res).toEqual({ MessageId: messageId });
   });
 

--- a/src/call-service.test.js
+++ b/src/call-service.test.js
@@ -20,7 +20,7 @@ describe('(call)', () => {
   });
 
   const lambdaService = {
-   id: 'my-func',
+    id: 'my-func',
     attributes: {
       type: 'function',
       arn: 'my-test-arn',
@@ -94,6 +94,22 @@ describe('(call)', () => {
 
     const event = { name: 'Test' };
 
+    const res = await ServiceDiscovery.publish('test-namespace.test-service->test-topic', event);
+    expect(SNS.prototype.publish).toBeCalledWith('test-topic', event, undefined);
+    expect(res).toEqual({ MessageId: messageId });
+  });
+
+  it('should publish an sns event with MessageAttributes if present in the options', async () => {
+    const messageId = 'abc123';
+    CloudmapAdapter.prototype.find = jest.fn().mockReturnValue(Promise.resolve(snsService));
+    SNS.prototype.publish = jest.fn().mockImplementation(() => Promise.resolve({
+      MessageId: messageId,
+    }));
+
+    expect.assertions(2);
+
+    const event = { name: 'Test' };
+
     const attributes = {
       tenant: {
         DataType: 'String',
@@ -101,7 +117,12 @@ describe('(call)', () => {
       },
     };
 
-    const res = await ServiceDiscovery.publish('test-namespace.test-service->test-topic', event, { attributes });
+    const options = {
+      foo: true,
+      attributes,
+    };
+
+    const res = await ServiceDiscovery.publish('test-namespace.test-service->test-topic', event, options);
     expect(SNS.prototype.publish).toBeCalledWith('test-topic', event, attributes);
     expect(res).toEqual({ MessageId: messageId });
   });

--- a/src/events/publisher.js
+++ b/src/events/publisher.js
@@ -8,8 +8,8 @@ class Publisher extends EventEmitter {
     this.eventHandler = eventHandler;
   }
 
-  publish(name, message) {
-    return this.eventHandler.publish(name, message);
+  publish(name, message, { attributes }) {
+    return this.eventHandler.publish(name, message, attributes);
   }
 }
 

--- a/src/events/sns.js
+++ b/src/events/sns.js
@@ -5,10 +5,11 @@ class SNS {
     this.client = client;
   }
 
-  async publish(name, event) {
+  async publish(name, event, attributes) {
     const { MessageId } = await this.client.publish({
       TopicArn: name,
       Message: JSON.stringify(event),
+      MessageAttributes: attributes,
     }).promise();
     return MessageId;
   }


### PR DESCRIPTION
As part of the Segment Settings cache invalidation, I've setup a filter policy to only invoke the invalidation lambda by particular message attributes. However, the `publish` method does not support the forwarding of message attributes to the underlying `SNS` SDK instance, thus I've introduced this capability in this PR.

```javascript
await ServiceDiscovery.publish('namspace.service-name->topic', event, {
  ...opts,
  attributes: { // Matches params.MessageAttributes from aws-sdk
    tenant: {
      DataType: 'String',
      StringValue: 'foo',
    },
  },
});
```
```
