### PR TITLE
feat: PF-2020 | support optional maxSockets override via opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,36 @@ const prod = WithAWSBackend();
 await prod.queue('latest.service->instance', request);
 ```
 
+### Local Package Testing
+
+To test changes locally without publishing to a registry:
+
+#### 1. Build and pack
+```bash
+npm run build
+npm pack
+# Creates peak-ai-ais-service-discovery-<version>.tgz
+```
+
+#### 2. Install in your consuming project
+```bash
+cd /path/to/your-project
+npm install /path/to/ais-service-discovery-js/peak-ai-ais-service-discovery-<version>.tgz
+```
+
+> If you hit peer dependency conflicts, add `--legacy-peer-deps`.
+
+#### 3. Verify the install
+```javascript
+const sd = require('@peak-ai/ais-service-discovery');
+console.log(sd); // should print the module exports
+```
+
+#### 4. Revert when done
+```bash
+npm install @peak-ai/ais-service-discovery@<original-version>
+```
+
 ### Integration Tests
 
 #### Prerequisites

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peak-ai/ais-service-discovery",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:peak-ai/ais-service-discovery-js.git",

--- a/src/functions/lambda-adapter.js
+++ b/src/functions/lambda-adapter.js
@@ -1,17 +1,44 @@
 'use strict';
 
+const { Lambda } = require('@aws-sdk/client-lambda');
+const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
+const https = require('https');
+
 class LambdaAdapter {
   constructor(client) {
     this.client = client;
+    this.clientCache = new Map();
+  }
+
+  getClient(maxSockets) {
+    if (this.clientCache.has(maxSockets)) {
+      return this.clientCache.get(maxSockets);
+    }
+    const client = new Lambda({
+      requestHandler: new NodeHttpHandler({
+        httpsAgent: new https.Agent({
+          keepAlive: true,
+          maxSockets,
+        }),
+        connectionTimeout: 8000,
+        socketTimeout: 8000,
+      }),
+      maxAttempts: 3,
+      retryMode: 'adaptive',
+    });
+    this.clientCache.set(maxSockets, client);
+    return client;
   }
 
   async call(name, body, opts) {
+    const { maxSockets, ...invokeOpts } = opts || {};
+    const client = maxSockets ? this.getClient(maxSockets) : this.client;
     const params = {
-      ...opts,
+      ...invokeOpts,
       FunctionName: name,
       Payload: JSON.stringify(body),
     };
-    const { Payload, StatusCode } = await this.client.invoke(params);
+    const { Payload, StatusCode } = await client.invoke(params);
 
      // Convert Uint8Array to String
      const decoder = new TextDecoder('utf-8');


### PR DESCRIPTION
## Description
- Adds optional `maxSockets` override support to the Lambda adapter, allowing callers to pass `maxSockets` in `opts` for fine-grained control over HTTP connection pooling
- Configures the default Lambda client with `keepAlive`, connection/socket timeouts, adaptive retry (maxAttempts: 3), and a default of 50 max sockets
- Caches custom Lambda clients per `maxSockets` value to avoid repeated instantiation
- Bumps version to 1.0.3

## Test plan
- [ ] Verify default Lambda client uses the configured maxSockets (50), keepAlive, and timeouts
- [ ] Verify passing `maxSockets` in opts creates and caches a custom Lambda client
- [ ] Verify subsequent calls with the same `maxSockets` reuse the cached client
- [ ] Verify other opts are passed through correctly to `invoke`

## Review Checks

_Put an `x` in the boxes that apply, Remove any lines that do not apply_
- [x] 📝 The commit message is clear and descriptive
- [x] 🔐 The Security Considerations section in the PR description is complete - **Please do not remove this**
- [ ] ✅ Tests for the changes have been added and run successfully including the new changes
- [ ] 📄 Documentation has been added / updated (for bug fixes / features)


## Security Considerations


- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 Adding or updating configuration files, development scripts etc.
- [x] ♻️ Refactoring (no functional changes, no api changes)
- [ ] 🧹 Chore (removing redunant files, fixing typos etc.)
- [ ] 📄 Documentation Update 
- [ ] ❓ Other (if none of the other choices apply)


